### PR TITLE
Enable uniform_bucket_level_access

### DIFF
--- a/infra/modules/storage/main.tf
+++ b/infra/modules/storage/main.tf
@@ -15,11 +15,12 @@
  */
 
 resource "google_storage_bucket" "main" {
-  project       = var.project_id
-  name          = var.name
-  location      = var.location
-  labels        = var.labels
-  force_destroy = true
+  project                     = var.project_id
+  name                        = var.name
+  location                    = var.location
+  labels                      = var.labels
+  force_destroy               = true
+  uniform_bucket_level_access = true
 }
 
 resource "google_storage_default_object_acl" "policy" {


### PR DESCRIPTION
Fixes: b/302700168

Enable uniform bucket level access to avoid the error:

Error: googleapi: Error 412: Request violates constraint 'constraints/storage.uniformBucketLevelAccess', conditionNotMet